### PR TITLE
Fix duplicated task execution in NDI frame creation

### DIFF
--- a/src/main/java/com/victorvalentim/zividomelive/manager/OutputManager.java
+++ b/src/main/java/com/victorvalentim/zividomelive/manager/OutputManager.java
@@ -284,14 +284,8 @@ public class OutputManager implements PConstants {
 			});
 		}
 
-		try {
-			ThreadManager.getExecutor().invokeAll(tasks);
-		} catch (Exception e) {
-			logger.severe("Error in parallel pixel copy: " + e.getMessage());
-		}
-
-		return tasks;
-	}
+                return tasks;
+        }
 
 	/**
 	 * Shuts down all output methods (NDI, Spout, Syphon).


### PR DESCRIPTION
## Summary
- prevent `prepareTasks` from executing its own tasks

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_684e1e6e416083319c07a1b6b3e6511e