### PR TITLE
Handle missing NDI library

### DIFF
--- a/src/main/java/com/victorvalentim/zividomelive/manager/OutputManager.java
+++ b/src/main/java/com/victorvalentim/zividomelive/manager/OutputManager.java
@@ -72,14 +72,18 @@ public class OutputManager implements PConstants {
 	/**
 	 * Initializes NDI output if it is not already enabled.
 	 */
-	private void initNDI() {
-		if (!ndiEnabled && ndiSender == null) {
-			ndiSender = new DevolaySender("ziviDomeLive NDI Output");
-			reusableFrame = new DevolayVideoFrame(); // Initialize reusable frame
-			ndiEnabled = true;
-			logger.info("NDI output initialized.");
-		}
-	}
+        private void initNDI() {
+                if (!ndiEnabled && ndiSender == null) {
+                        try {
+                                ndiSender = new DevolaySender("ziviDomeLive NDI Output");
+                                reusableFrame = new DevolayVideoFrame(); // Initialize reusable frame
+                                ndiEnabled = true;
+                                logger.info("NDI output initialized.");
+                        } catch (ExceptionInInitializerError | UnsatisfiedLinkError | IllegalStateException e) {
+                                logger.warning("NDI cannot be started on this platform.");
+                        }
+                }
+        }
 
 	/**
 	 * Sets up Syphon (for macOS) or Spout (for Windows) based on the OS.


### PR DESCRIPTION
## Summary
- protect NDI startup from missing dependencies

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_684ff290d7a483318cc722954c0c0bec