### PR TITLE
v1.5 improvements: resource cleanup, lazy output pipeline, log throttle, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@
 >>Due to the absence of a native library for **NDI** in Processing, Linux users will not have access to external integration features, such as those provided by **Syphon** or **Spout** on macOS and Windows.
 >
 
->[!WARNING]
->**OpenGL Error 1282**:
-> Some users may encounter the following OpenGL error in the Processing console:
+>[!NOTE]
+>**OpenGL Error 1282 (resolved)**:
+> Earlier versions could emit the following OpenGL error in the Processing console:
 >   ```
 >   OpenGL error 1282 at bot endDraw(): invalid operation
 >   ```
->This error is related to specific OpenGL calls within Processing, but it does not impact the functionality of the **ziviDomeLive** library. Your visuals and performance should remain unaffected, and you can safely ignore this warning.
+>This was caused by invalid OpenGL state during output frame capture and has been fixed as of version 1.4.0. If you still see this warning, make sure you are running the latest version of **ziviDomeLive**.
 >
 
 ## Installation

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,6 +106,11 @@ dependencies {
     // Processing core is needed at test runtime for PApplet static math helpers
     // (sin, cos, sqrt, constrain) used by Quaternion and related classes.
     testImplementation(group = "org.processing", name = "core", version = processingCoreVersion)
+    // Local sketchbook libraries are needed at test runtime to load classes
+    // that reference ControlP5/Syphon/Spout types (zividomelive, managers).
+    testRuntimeOnly(fileTree("src/main/libs/controlP5.jar"))
+    testRuntimeOnly(fileTree("src/main/libs/spout.jar"))
+    testRuntimeOnly(fileTree("src/main/libs/Syphon.jar"))
 }
 
 tasks.test {

--- a/src/main/java/com/victorvalentim/zividomelive/SceneManager.java
+++ b/src/main/java/com/victorvalentim/zividomelive/SceneManager.java
@@ -66,7 +66,18 @@ public class SceneManager {
 			LOGGER.info("Scene auto-registered during activation: " + scene.getName());
 		}
 
+		if (currentSceneIndex == index) {
+			LOGGER.info("Scene already active, skipping reinitialization: " + scene.getName());
+			return;
+		}
+
+		Scene leaving = (currentSceneIndex >= 0 && currentSceneIndex < scenes.size())
+				? scenes.get(currentSceneIndex)
+				: null;
 		currentSceneIndex = index;
+		if (leaving != null) {
+			leaving.dispose();
+		}
 		Scene activeScene = scenes.get(currentSceneIndex);
 		activeScene.setupScene();
 		LOGGER.info("Scene activated: " + activeScene.getName());
@@ -104,6 +115,7 @@ public class SceneManager {
 		currentSceneIndex = (currentSceneIndex + 1) % scenes.size();
 
 		if (previousIndex != currentSceneIndex) {
+			disposeScene(previousIndex);
 			Scene newScene = getCurrentScene();
 			newScene.setupScene();
 			LOGGER.info("Switched to the next scene: " + newScene.getName());
@@ -123,6 +135,7 @@ public class SceneManager {
 		int previousIndex = currentSceneIndex;
 		currentSceneIndex = (currentSceneIndex - 1 + scenes.size()) % scenes.size();
 		if (previousIndex != currentSceneIndex) {
+			disposeScene(previousIndex);
 			Scene newScene = getCurrentScene();
 			newScene.setupScene();
 			LOGGER.info("Switched to the previous scene: " + newScene.getName());
@@ -155,11 +168,33 @@ public class SceneManager {
 			return;
 		}
 
+		if (currentSceneIndex == index) {
+			return; // already active, do not reinitialize
+		}
+
+		int previousIndex = currentSceneIndex;
 		currentSceneIndex = index;
+		disposeScene(previousIndex);
 		Scene newScene = getCurrentScene();
 		if (newScene != null) {
 			newScene.setupScene();
 			LOGGER.info("Scene set to index " + index + ": " + newScene.getName());
+		}
+	}
+
+	/**
+	 * Disposes the scene at the given index, releasing its resources.
+	 *
+	 * @param index index of the scene to dispose; ignored if out of range
+	 */
+	private void disposeScene(int index) {
+		if (index < 0 || index >= scenes.size()) {
+			return;
+		}
+		try {
+			scenes.get(index).dispose();
+		} catch (RuntimeException e) {
+			LOGGER.warning("Error disposing scene " + scenes.get(index).getName() + ": " + e.getMessage());
 		}
 	}
 

--- a/src/main/java/com/victorvalentim/zividomelive/manager/ControlManager.java
+++ b/src/main/java/com/victorvalentim/zividomelive/manager/ControlManager.java
@@ -14,21 +14,21 @@ import java.util.function.Consumer;
  */
 public class ControlManager {
 
-    ControlP5 cp5;
-    boolean numberboxActive = false;
-    int baseResolution;
-    zividomelive parent;
-    Toggle previewToggle;
-    Toggle ndiToggle;
-    Toggle spoutToggle;
-    Toggle syphonToggle;
-    DropdownList resolutionDropdown;
-    DropdownList viewModeDropdown;
-    DropdownList ndiViewDropdown;
-    DropdownList spoutViewDropdown;
-    DropdownList syphonViewDropdown;
-    Textlabel fpsLabel;
-    PApplet p;
+    private ControlP5 cp5;
+    private boolean numberboxActive = false;
+    private int baseResolution;
+    private zividomelive parent;
+    private Toggle previewToggle;
+    private Toggle ndiToggle;
+    private Toggle spoutToggle;
+    private Toggle syphonToggle;
+    private DropdownList resolutionDropdown;
+    private DropdownList viewModeDropdown;
+    private DropdownList ndiViewDropdown;
+    private DropdownList spoutViewDropdown;
+    private DropdownList syphonViewDropdown;
+    private Textlabel fpsLabel;
+    private PApplet p;
 
     // Layout configuration
     // Layout configuration
@@ -355,6 +355,19 @@ public class ControlManager {
         cp5.hide();
     }
 
+    /**
+     * Synchronizes the ControlP5 widgets with the externally toggled panel visibility state.
+     *
+     * @param visible true to show the panel widgets, false to hide them
+     */
+    public void syncPanelVisibility(boolean visible) {
+        if (visible) {
+            show();
+        } else {
+            hide();
+        }
+    }
+
     void makeEditable(Numberbox n) {
         final NumberboxInput nin = new NumberboxInput(n, p);
         n.onClick(theEvent -> {
@@ -383,7 +396,6 @@ public class ControlManager {
                 break;
             case "size":
                 parent.setFishSize(value);
-                parent.getFisheyeDomemaster().setSizePercentage(value);
                 break;
         }
     }

--- a/src/main/java/com/victorvalentim/zividomelive/manager/OutputManager.java
+++ b/src/main/java/com/victorvalentim/zividomelive/manager/OutputManager.java
@@ -133,7 +133,7 @@ public class OutputManager implements PConstants {
 				spoutEnabled = true;
 				logger.info("Spout initialized for Windows.");
 			}
-		} catch (Exception e) {
+		} catch (Exception | LinkageError e) {
 			logger.log(Level.SEVERE, "setupSyphonOrSpout failed.", e);
 		}
 	}

--- a/src/main/java/com/victorvalentim/zividomelive/render/modes/FisheyeDomemaster.java
+++ b/src/main/java/com/victorvalentim/zividomelive/render/modes/FisheyeDomemaster.java
@@ -62,9 +62,9 @@ public class FisheyeDomemaster {
      */
     void setFOV(float fov) {
         if (domemasterShader == null) {
-            initializeDomemaster();
+            LOGGER.warning("Domemaster shader not initialized; skipping FOV update.");
+            return;
         }
-        assert domemasterShader != null;
         domemasterShader.set("fov", fov);
     }
 
@@ -78,6 +78,15 @@ public class FisheyeDomemaster {
     }
 
     /**
+     * Returns the current size percentage of the domemaster projection.
+     *
+     * @return the size percentage, between 0 and 100
+     */
+    public float getSizePercentage() {
+        return sizePercentage;
+    }
+
+    /**
      * Applies the shader to the equirectangular map and renders the domemaster projection.
      *
      * @param equirectangular the PGraphics object representing the equirectangular map
@@ -86,6 +95,10 @@ public class FisheyeDomemaster {
     public void applyShader(PGraphicsOpenGL equirectangular, float fov) {
         if (equirectangular == null) {
             LOGGER.warning("Equirectangular PGraphics is null.");
+            return;
+        }
+        if (domemasterShader == null) {
+            LOGGER.warning("Domemaster shader not initialized; skipping shader pass.");
             return;
         }
 

--- a/src/main/java/com/victorvalentim/zividomelive/support/LogManager.java
+++ b/src/main/java/com/victorvalentim/zividomelive/support/LogManager.java
@@ -19,6 +19,8 @@ public class LogManager {
 	private static final Logger globalLogger = Logger.getLogger("com.victorvalentim.zividomelive");
 	private static boolean isConfigured = false;
 	private static final AtomicReference<String> lastLogMessage = new AtomicReference<>("");
+	private static final java.util.concurrent.atomic.AtomicLong lastLogTimestamp = new java.util.concurrent.atomic.AtomicLong(0L);
+	private static final long DUPLICATE_LOG_THROTTLE_MS = 5000L;
 	private static Mode currentMode = Mode.RELEASE;
 
 	private LogManager() {}
@@ -88,14 +90,18 @@ public class LogManager {
 			globalLogger.log(Level.WARNING, "FileHandler configuration failed. Logs will only appear in the console.", e);
 		}
 
-		// Filter to suppress duplicate log messages (thread-safe)
+		// Time-based throttle for duplicate log messages: the same message is
+		// allowed through at most once every DUPLICATE_LOG_THROTTLE_MS.
 		globalLogger.setFilter(record -> {
 			String message = record.getMessage();
+			long now = System.currentTimeMillis();
 			String previousMessage = lastLogMessage.get();
-			if (message != null && message.equals(previousMessage)) {
-				return false; // Suppress duplicate message
+			if (message != null && message.equals(previousMessage)
+					&& (now - lastLogTimestamp.get()) < DUPLICATE_LOG_THROTTLE_MS) {
+				return false; // Suppress duplicate message within throttle window
 			}
 			lastLogMessage.set(message);
+			lastLogTimestamp.set(now);
 			return true;
 		});
 

--- a/src/main/java/com/victorvalentim/zividomelive/zividomelive.java
+++ b/src/main/java/com/victorvalentim/zividomelive/zividomelive.java
@@ -49,8 +49,14 @@ public class zividomelive implements PConstants {
 	private int outputResolution = 1024;
 	private boolean showControlPanel = true;
 	private boolean showPreview = false;
-	private final boolean enableOutput = false;
 	private boolean controlPanelShownOnce = false;
+	private int targetFrameRate = 60;
+
+	// Shader resource paths (packaged under data/shaders by the build).
+	private static final String EQUIRECT_VERT = "data/shaders/equirectangular.vert";
+	private static final String EQUIRECT_FRAG = "data/shaders/equirectangular.frag";
+	private static final String DOME_VERT = "data/shaders/domemaster.vert";
+	private static final String DOME_FRAG = "data/shaders/domemaster.frag";
 
 	private ControlManager controlManager;
 	// Output pipeline (high resolution)
@@ -181,8 +187,8 @@ public class zividomelive implements PConstants {
 		LOGGER.info("Starting setup...");
 
 		try {
-			p.frameRate(70);
-			LOGGER.info("Frame rate set to 70.");
+			p.frameRate(targetFrameRate);
+			LOGGER.info("Frame rate set to " + targetFrameRate + ".");
 		} catch (Exception e) {
 			LOGGER.severe("Error setting frame rate: " + e.getMessage());
 		}
@@ -292,34 +298,43 @@ public class zividomelive implements PConstants {
 	}
 
 	/**
-	 * Initializes various renderers required for different views.
+	 * Initializes renderers required for preview and standard views.
+	 * High-resolution output renderers are allocated lazily when an output is active.
 	 */
 	void initializeRenderers() {
 		try {
 			LOGGER.info("Initializing renderers...");
 
-			// Paths to shader files
-			String equirectangularVertexShaderPath = "data/shaders/equirectangular.vert";
-			String equirectangularFragmentShaderPath = "data/shaders/equirectangular.frag";
-			String domemasterVertexShaderPath = "data/shaders/domemaster.vert";
-			String domemasterFragmentShaderPath = "data/shaders/domemaster.frag";
-
-			cubemapRenderer = new CubemapRenderer(outputResolution, p);
-			LOGGER.info("CubemapRenderer initialized.");
-			equirectangularRenderer = new EquirectangularRenderer(outputResolution, equirectangularFragmentShaderPath, equirectangularVertexShaderPath, p);
-			LOGGER.info("EquirectangularRenderer initialized.");
 			standardRenderer = new StandardRenderer(p, p.width, p.height, currentScene);
 			LOGGER.info("StandardRenderer initialized.");
-			fisheyeDomemaster = new FisheyeDomemaster(outputResolution, domemasterFragmentShaderPath, domemasterVertexShaderPath, p);
-			LOGGER.info("FisheyeDomemaster initialized.");
-			cubemapViewRenderer = new CubemapViewRenderer(p, outputResolution);
-			LOGGER.info("CubemapViewRenderer initialized.");
+			if (isEnableOutput()) {
+				initializeOutputRenderers();
+			}
 			initializePreviewRenderers();
 			LOGGER.info("Preview renderers initialized.");
 			LOGGER.info("Renderers initialized successfully.");
 		} catch (Exception e) {
 			LOGGER.severe("Error initializing renderers");
 		}
+	}
+
+	/**
+	 * Allocates the high-resolution output renderers if they are not yet available.
+	 * Must be called from the Processing draw thread.
+	 */
+	private void initializeOutputRenderers() {
+		if (cubemapRenderer != null && equirectangularRenderer != null
+				&& fisheyeDomemaster != null && cubemapViewRenderer != null) {
+			return;
+		}
+		cubemapRenderer = new CubemapRenderer(outputResolution, p);
+		LOGGER.info("CubemapRenderer initialized.");
+		equirectangularRenderer = new EquirectangularRenderer(outputResolution, EQUIRECT_FRAG, EQUIRECT_VERT, p);
+		LOGGER.info("EquirectangularRenderer initialized.");
+		fisheyeDomemaster = new FisheyeDomemaster(outputResolution, DOME_FRAG, DOME_VERT, p);
+		LOGGER.info("FisheyeDomemaster initialized.");
+		cubemapViewRenderer = new CubemapViewRenderer(p, outputResolution);
+		LOGGER.info("CubemapViewRenderer initialized.");
 	}
 
 	private int computePreviewResolution() {
@@ -330,14 +345,10 @@ public class zividomelive implements PConstants {
 
 	private void initializePreviewRenderers() {
 		previewResolution = computePreviewResolution();
-		String equirectangularVertexShaderPath = "data/shaders/equirectangular.vert";
-		String equirectangularFragmentShaderPath = "data/shaders/equirectangular.frag";
-		String domemasterVertexShaderPath = "data/shaders/domemaster.vert";
-		String domemasterFragmentShaderPath = "data/shaders/domemaster.frag";
 
 		previewCubemapRenderer = new CubemapRenderer(previewResolution, p);
-		previewEquirectangularRenderer = new EquirectangularRenderer(previewResolution, equirectangularFragmentShaderPath, equirectangularVertexShaderPath, p);
-		previewFisheyeDomemaster = new FisheyeDomemaster(previewResolution, domemasterFragmentShaderPath, domemasterVertexShaderPath, p);
+		previewEquirectangularRenderer = new EquirectangularRenderer(previewResolution, EQUIRECT_FRAG, EQUIRECT_VERT, p);
+		previewFisheyeDomemaster = new FisheyeDomemaster(previewResolution, DOME_FRAG, DOME_VERT, p);
 		previewCubemapViewRenderer = new CubemapViewRenderer(p, previewResolution);
 	}
 
@@ -412,7 +423,7 @@ public class zividomelive implements PConstants {
 	}
 
 	void renderContent() {
-		if (cubemapRenderer == null || equirectangularRenderer == null || fisheyeDomemaster == null || standardRenderer == null || currentScene == null) {
+		if (standardRenderer == null || currentScene == null) {
 			LOGGER.severe("Error: Renderer or scene not initialized.");
 			return;
 		}
@@ -421,8 +432,9 @@ public class zividomelive implements PConstants {
 		handleGraphicsReset();
 		ensurePreviewRenderers();
 
-		// High-res pipeline is only required for external outputs.
+		// High-res pipeline is only required for external outputs; allocated lazily.
 		if (isEnableOutput()) {
+			initializeOutputRenderers();
 			captureCubemap();
 			updateRenderViews();
 			outputManager.sendOutput();
@@ -543,6 +555,7 @@ public class zividomelive implements PConstants {
 	private void renderWithCurrentView() {
 		clearBackground();
 		handleGraphicsReset();
+		initializeOutputRenderers();
 		captureCubemap();
 		updateRenderViews();
 		displayCurrentView();
@@ -551,11 +564,11 @@ public class zividomelive implements PConstants {
 	}
 
 	/**
-	 * Renders the fisheye domemaster view by applying the shader and displaying the view.
-	 * If the FisheyeDomemaster is not initialized, an error message is printed.
+	 * Renders the fisheye domemaster view, switching the current view mode to FISHEYE_DOMEMASTER.
 	 */
 	public void renderFisheyeDomemaster() {
-		if (fisheyeDomemaster != null) {
+		setCurrentView(ViewType.FISHEYE_DOMEMASTER);
+		if (fisheyeDomemaster != null || previewFisheyeDomemaster != null) {
 			renderWithCurrentView();
 		} else {
 			LOGGER.severe("Error: FisheyeDomemaster not initialized.");
@@ -563,11 +576,11 @@ public class zividomelive implements PConstants {
 	}
 
 	/**
-	 * Renders the equirectangular view by invoking the EquirectangularRenderer.
-	 * If the EquirectangularRenderer is not initialized, an error message is printed.
+	 * Renders the equirectangular view, switching the current view mode to EQUIRECTANGULAR.
 	 */
 	public void renderEquirectangular() {
-		if (equirectangularRenderer != null) {
+		setCurrentView(ViewType.EQUIRECTANGULAR);
+		if (equirectangularRenderer != null || previewEquirectangularRenderer != null) {
 			renderWithCurrentView();
 		} else {
 			LOGGER.severe("Error: EquirectangularRenderer not initialized.");
@@ -575,11 +588,11 @@ public class zividomelive implements PConstants {
 	}
 
 	/**
-	 * Renders the cubemap view by drawing the cubemap faces to the graphics and displaying the view.
-	 * If the CubemapViewRenderer is not initialized, an error message is printed.
+	 * Renders the cubemap view, switching the current view mode to CUBEMAP.
 	 */
 	public void renderCubemap() {
-		if (cubemapViewRenderer != null) {
+		setCurrentView(ViewType.CUBEMAP);
+		if (cubemapViewRenderer != null || previewCubemapViewRenderer != null) {
 			renderWithCurrentView();
 		} else {
 			LOGGER.severe("Error: CubemapViewRenderer not initialized.");
@@ -587,10 +600,10 @@ public class zividomelive implements PConstants {
 	}
 
 	/**
-	 * Renders the standard view by invoking the StandardRenderer.
-	 * If the StandardRenderer is not initialized, an error message is printed.
+	 * Renders the standard view, switching the current view mode to STANDARD.
 	 */
 	public void renderStandard() {
+		setCurrentView(ViewType.STANDARD);
 		if (standardRenderer != null) {
 			renderWithCurrentView();
 		} else {
@@ -681,15 +694,6 @@ public class zividomelive implements PConstants {
 		pendingOutputReset = true;
 		pendingOutputResolution = newResolution;
 		LOGGER.info("Changing output resolution to: " + newResolution);
-		ThreadManager.getExecutor().submit(() -> {
-			try {
-				Thread.sleep(100);
-				LOGGER.info("Output resolution change processed.");
-			} catch (InterruptedException e) {
-				LOGGER.severe("Error during output resolution change processing");
-				Thread.currentThread().interrupt();
-			}
-		});
 	}
 
 	/**
@@ -773,6 +777,7 @@ public class zividomelive implements PConstants {
 				switch (event.getKey()) {
 					case 'h':
 						showControlPanel = !showControlPanel;
+						controlManager.syncPanelVisibility(showControlPanel);
 						LOGGER.info("Toggling control panel visibility: " + showControlPanel);
 						break;
 
@@ -890,6 +895,12 @@ public class zividomelive implements PConstants {
 	 */
 	public void setFishSize(float fishSize) {
 		this.fishSize = fishSize;
+		if (fisheyeDomemaster != null) {
+			fisheyeDomemaster.setSizePercentage(fishSize);
+		}
+		if (previewFisheyeDomemaster != null) {
+			previewFisheyeDomemaster.setSizePercentage(fishSize);
+		}
 	}
 
 	/**
@@ -980,6 +991,32 @@ public class zividomelive implements PConstants {
 	 */
 	public void setCurrentView(ViewType currentView) {
 		this.currentView = currentView;
+	}
+
+	/**
+	 * Sets the target frame rate applied during setup. Defaults to 60.
+	 * Call before setup() to take effect at startup; calling afterwards applies immediately.
+	 *
+	 * @param fps desired frame rate, must be positive
+	 */
+	public void setTargetFrameRate(int fps) {
+		if (fps <= 0) {
+			LOGGER.warning("Ignoring invalid target frame rate: " + fps);
+			return;
+		}
+		this.targetFrameRate = fps;
+		if (initState != InitState.NOT_INITIALIZED) {
+			p.frameRate(fps);
+		}
+	}
+
+	/**
+	 * Returns the configured target frame rate.
+	 *
+	 * @return target frame rate in frames per second
+	 */
+	public int getTargetFrameRate() {
+		return targetFrameRate;
 	}
 
 	/**

--- a/src/test/java/com/victorvalentim/zividomelive/ZividomeliveLifecycleTest.java
+++ b/src/test/java/com/victorvalentim/zividomelive/ZividomeliveLifecycleTest.java
@@ -1,0 +1,68 @@
+package com.victorvalentim.zividomelive;
+
+import org.junit.jupiter.api.Test;
+import processing.core.PApplet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ZividomeliveLifecycleTest {
+
+	@Test
+	void constructorRejectsNullApplet() {
+		assertThrows(IllegalArgumentException.class, () -> new zividomelive(null));
+	}
+
+	@Test
+	void initialStateIsNotInitialized() {
+		zividomelive lib = new zividomelive(new PApplet());
+		assertEquals(zividomelive.InitState.NOT_INITIALIZED, lib.getInitState());
+	}
+
+	@Test
+	void initializeManagersBeforeSetupKeepsStateUnchanged() {
+		zividomelive lib = new zividomelive(new PApplet());
+		lib.initializeManagers();
+		assertEquals(zividomelive.InitState.NOT_INITIALIZED, lib.getInitState(),
+				"initializeManagers must not advance state before setup completes");
+	}
+
+	@Test
+	void setupTransitionsToSetupComplete() {
+		zividomelive lib = new zividomelive(new PApplet());
+		lib.setup();
+		assertEquals(zividomelive.InitState.SETUP_COMPLETE, lib.getInitState());
+	}
+
+	@Test
+	void targetFrameRateDefaultsTo60AndRejectsInvalidValues() {
+		zividomelive lib = new zividomelive(new PApplet());
+		assertEquals(60, lib.getTargetFrameRate());
+
+		lib.setTargetFrameRate(0);
+		assertEquals(60, lib.getTargetFrameRate(), "Non-positive values must be ignored");
+
+		lib.setTargetFrameRate(-30);
+		assertEquals(60, lib.getTargetFrameRate(), "Non-positive values must be ignored");
+
+		lib.setTargetFrameRate(120);
+		assertEquals(120, lib.getTargetFrameRate());
+	}
+
+	@Test
+	void isEnableOutputDelegatesToOutputManager() {
+		zividomelive lib = new zividomelive(new PApplet());
+		lib.setup();
+
+		OutputManagerState state = readOutputState(lib);
+		assertEquals(state.anyEnabled, lib.isEnableOutput(),
+				"isEnableOutput must mirror the OutputManager enabled flags");
+	}
+
+	private record OutputManagerState(boolean anyEnabled) {}
+
+	private OutputManagerState readOutputState(zividomelive lib) {
+		var om = lib.getOutputManager();
+		assertNotNull(om, "OutputManager must be created during setup");
+		return new OutputManagerState(om.isNdiEnabled() || om.isSpoutEnabled() || om.isSyphonEnabled());
+	}
+}

--- a/src/test/java/com/victorvalentim/zividomelive/manager/OutputManagerTest.java
+++ b/src/test/java/com/victorvalentim/zividomelive/manager/OutputManagerTest.java
@@ -1,0 +1,95 @@
+package com.victorvalentim.zividomelive.manager;
+
+import com.victorvalentim.zividomelive.zividomelive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assumptions;
+import processing.core.PApplet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OutputManagerTest {
+
+	private OutputManager outputManager;
+
+	@BeforeEach
+	void createOutputManager() {
+		zividomelive lib = new zividomelive(new PApplet());
+		try {
+			outputManager = new OutputManager(lib);
+		} catch (Throwable t) {
+			// Platform-specific native bindings unavailable; skip instead of failing.
+			Assumptions.assumeTrue(false, "OutputManager unavailable on this platform: " + t);
+		}
+	}
+
+	@Test
+	void toggleOutputIgnoresEmptyMethod() {
+		assertDoesNotThrow(() -> outputManager.toggleOutput(""));
+		assertDoesNotThrow(() -> outputManager.toggleOutput("   "));
+		assertDoesNotThrow(() -> outputManager.toggleOutput(null));
+	}
+
+	@Test
+	void toggleOutputIgnoresUnknownMethod() {
+		boolean ndiBefore = outputManager.isNdiEnabled();
+		boolean spoutBefore = outputManager.isSpoutEnabled();
+		boolean syphonBefore = outputManager.isSyphonEnabled();
+
+		assertDoesNotThrow(() -> outputManager.toggleOutput("unknown-output"));
+
+		assertEquals(ndiBefore, outputManager.isNdiEnabled());
+		assertEquals(spoutBefore, outputManager.isSpoutEnabled());
+		assertEquals(syphonBefore, outputManager.isSyphonEnabled());
+	}
+
+	@Test
+	void spoutToggleIsIgnoredOnUnsupportedPlatform() {
+		String os = System.getProperty("os.name").toLowerCase();
+		Assumptions.assumeFalse(os.contains("win"), "Spout is supported on Windows");
+
+		outputManager.toggleOutput("spout");
+		assertFalse(outputManager.isSpoutEnabled(),
+				"Spout must remain disabled on non-Windows platforms");
+	}
+
+	@Test
+	void syphonToggleIsIgnoredOnUnsupportedPlatform() {
+		String os = System.getProperty("os.name").toLowerCase();
+		Assumptions.assumeFalse(os.contains("mac"), "Syphon is supported on macOS");
+
+		outputManager.toggleOutput("syphon");
+		assertFalse(outputManager.isSyphonEnabled(),
+				"Syphon must remain disabled on non-macOS platforms");
+	}
+
+	@Test
+	void ndiToggleEnablesAndDisablesWhenAvailable() {
+		boolean before = outputManager.isNdiEnabled();
+		outputManager.toggleOutput("ndi");
+		boolean after = outputManager.isNdiEnabled();
+
+		if (after != before) {
+			// NDI natives are available: toggling back must restore the previous state.
+			outputManager.toggleOutput("ndi");
+			assertEquals(before, outputManager.isNdiEnabled());
+		} else {
+			// NDI unavailable on this platform: state must remain disabled.
+			assertFalse(after);
+		}
+	}
+
+	@Test
+	void outputViewsDefaultToFisheyeDomemaster() {
+		for (OutputManager.OutputType type : OutputManager.OutputType.values()) {
+			assertEquals(zividomelive.ViewType.FISHEYE_DOMEMASTER, outputManager.getViewForOutput(type));
+		}
+	}
+
+	@Test
+	void setViewForOutputUpdatesMapping() {
+		outputManager.setViewForOutput(OutputManager.OutputType.NDI, zividomelive.ViewType.EQUIRECTANGULAR);
+		assertEquals(zividomelive.ViewType.EQUIRECTANGULAR,
+				outputManager.getViewForOutput(OutputManager.OutputType.NDI));
+	}
+}

--- a/src/test/java/com/victorvalentim/zividomelive/render/camera/OrbitCameraTest.java
+++ b/src/test/java/com/victorvalentim/zividomelive/render/camera/OrbitCameraTest.java
@@ -1,0 +1,92 @@
+package com.victorvalentim.zividomelive.render.camera;
+
+import com.victorvalentim.zividomelive.render.Quaternion;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OrbitCameraTest {
+
+	private static final float EPSILON = 1e-4f;
+
+	@Test
+	void defaultConstructorUsesDefaultDistance() {
+		OrbitCamera camera = new OrbitCamera();
+		assertEquals(1500f, camera.getDistance(), EPSILON);
+	}
+
+	@Test
+	void zoomIsClampedToDistanceLimits() {
+		OrbitCamera camera = new OrbitCamera(100f);
+		camera.setDistanceLimits(10f, 200f);
+
+		camera.zoom(10000f);
+		settle(camera);
+		assertEquals(200f, camera.getDistance(), EPSILON);
+
+		camera.zoom(-10000f);
+		settle(camera);
+		assertEquals(10f, camera.getDistance(), EPSILON);
+	}
+
+	@Test
+	void collapseGuardPreventsCrossingZero() {
+		OrbitCamera camera = new OrbitCamera(50f);
+		camera.setDistanceLimits(-1000f, 1000f);
+		camera.setCollapseGuard(5f);
+
+		// Attempt to zoom through zero from the positive side.
+		camera.zoom(-100f);
+		settle(camera);
+		assertEquals(5f, camera.getDistance(), EPSILON,
+				"Distance should stop at the collapse guard boundary instead of crossing zero");
+	}
+
+	@Test
+	void collapseGuardKeepsDistanceOutsideDeadZone() {
+		OrbitCamera camera = new OrbitCamera(50f);
+		camera.setDistanceLimits(-1000f, 1000f);
+		camera.setCollapseGuard(10f);
+
+		camera.setDistance(2f); // inside the dead zone
+		settle(camera);
+		assertEquals(10f, camera.getDistance(), EPSILON);
+	}
+
+	@Test
+	void snapToAppliesImmediately() {
+		OrbitCamera camera = new OrbitCamera(100f);
+		Quaternion q = new Quaternion(0, 0, 0, 1);
+		camera.snapTo(1f, 2f, 3f, q, 42f);
+
+		assertEquals(42f, camera.getDistance(), EPSILON);
+		assertEquals(1f, camera.getTarget().x, EPSILON);
+		assertEquals(2f, camera.getTarget().y, EPSILON);
+		assertEquals(3f, camera.getTarget().z, EPSILON);
+	}
+
+	@Test
+	void resetRestoresOriginAndDistance() {
+		OrbitCamera camera = new OrbitCamera(100f);
+		camera.setTarget(5f, 5f, 5f);
+		camera.zoom(50f);
+		settle(camera);
+
+		camera.reset(300f);
+		assertEquals(300f, camera.getDistance(), EPSILON);
+		assertEquals(0f, camera.getTarget().x, EPSILON);
+		assertEquals(0f, camera.getTarget().y, EPSILON);
+		assertEquals(0f, camera.getTarget().z, EPSILON);
+		Quaternion orientation = camera.getOrientation();
+		assertEquals(0f, orientation.x, EPSILON);
+		assertEquals(0f, orientation.y, EPSILON);
+		assertEquals(0f, orientation.z, EPSILON);
+		assertEquals(1f, Math.abs(orientation.w), EPSILON);
+	}
+
+	private static void settle(OrbitCamera camera) {
+		for (int i = 0; i < 200; i++) {
+			camera.update();
+		}
+	}
+}

--- a/src/test/java/com/victorvalentim/zividomelive/render/modes/FisheyeDomemasterTest.java
+++ b/src/test/java/com/victorvalentim/zividomelive/render/modes/FisheyeDomemasterTest.java
@@ -1,0 +1,56 @@
+package com.victorvalentim.zividomelive.render.modes;
+
+import org.junit.jupiter.api.Test;
+import processing.core.PApplet;
+import processing.opengl.PShader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FisheyeDomemasterTest {
+
+	/**
+	 * Headless PApplet stub that avoids any GPU/graphics context.
+	 * loadShader returns null so shader-dependent paths can be exercised safely.
+	 */
+	private static class StubApplet extends PApplet {
+		@Override
+		public PShader loadShader(String fragFilename, String vertFilename) {
+			return null;
+		}
+	}
+
+	private FisheyeDomemaster newFisheye() {
+		return new FisheyeDomemaster(1024, "frag", "vert", new StubApplet());
+	}
+
+	@Test
+	void sizePercentageDefaultsTo100() {
+		assertEquals(100.0f, newFisheye().getSizePercentage(), 1e-6f);
+	}
+
+	@Test
+	void setSizePercentageConstrainsToValidRange() {
+		FisheyeDomemaster fisheye = newFisheye();
+
+		fisheye.setSizePercentage(150f);
+		assertEquals(100f, fisheye.getSizePercentage(), 1e-6f);
+
+		fisheye.setSizePercentage(-10f);
+		assertEquals(0f, fisheye.getSizePercentage(), 1e-6f);
+
+		fisheye.setSizePercentage(42.5f);
+		assertEquals(42.5f, fisheye.getSizePercentage(), 1e-6f);
+	}
+
+	@Test
+	void setFOVWithNullShaderDoesNotThrow() {
+		FisheyeDomemaster fisheye = newFisheye();
+		assertDoesNotThrow(() -> fisheye.setFOV(210f));
+	}
+
+	@Test
+	void applyShaderWithNullInputsDoesNotThrow() {
+		FisheyeDomemaster fisheye = newFisheye();
+		assertDoesNotThrow(() -> fisheye.applyShader(null, 210f));
+	}
+}

--- a/src/test/java/com/victorvalentim/zividomelive/support/LogManagerTest.java
+++ b/src/test/java/com/victorvalentim/zividomelive/support/LogManagerTest.java
@@ -1,0 +1,55 @@
+package com.victorvalentim.zividomelive.support;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.Filter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LogManagerTest {
+
+	@AfterEach
+	void restoreReleaseMode() {
+		LogManager.setMode(LogManager.Mode.RELEASE);
+	}
+
+	@Test
+	void setModeRejectsNull() {
+		assertThrows(IllegalArgumentException.class, () -> LogManager.setMode(null));
+	}
+
+	@Test
+	void setModeUpdatesGetMode() {
+		LogManager.setMode(LogManager.Mode.DEBUG);
+		assertEquals(LogManager.Mode.DEBUG, LogManager.getMode());
+
+		LogManager.setMode(LogManager.Mode.RELEASE);
+		assertEquals(LogManager.Mode.RELEASE, LogManager.getMode());
+	}
+
+	@Test
+	void releaseModeDisablesLogging() {
+		LogManager.setMode(LogManager.Mode.RELEASE);
+		Logger logger = LogManager.getLogger();
+		assertFalse(logger.isLoggable(Level.SEVERE));
+	}
+
+	@Test
+	void duplicateMessagesAreThrottledWithinWindow() {
+		LogManager.setMode(LogManager.Mode.DEBUG);
+		Filter filter = LogManager.getLogger().getFilter();
+		assertNotNull(filter, "DEBUG mode should install a duplicate-throttling filter");
+
+		LogRecord first = new LogRecord(Level.INFO, "throttle-test-message");
+		LogRecord duplicate = new LogRecord(Level.INFO, "throttle-test-message");
+		LogRecord different = new LogRecord(Level.INFO, "another-message");
+
+		assertTrue(filter.isLoggable(first), "First occurrence must pass");
+		assertFalse(filter.isLoggable(duplicate), "Immediate duplicate must be suppressed");
+		assertTrue(filter.isLoggable(different), "A different message must pass");
+	}
+}


### PR DESCRIPTION
## Summary

Implements the pending v1.5 improvements (items 3.1–3.12 of the repo guidance) plus the priority test coverage gaps (section 4).

### Core changes

- **SceneManager**: `dispose()` is now called on the outgoing scene in `nextScene()`, `previousScene()`, `setCurrentSceneIndex()` and `activateScene()` (fixes GPU resource leak); `activateScene()` no longer reinitializes an already-active scene.
- **zividomelive**:
  - Removed dead `enableOutput` field.
  - `resetGraphics()` no longer submits a useless sleep task to the executor.
  - New `setTargetFrameRate(int)` / `getTargetFrameRate()` (default 60) replaces the hardcoded `frameRate(70)`.
  - `renderFisheyeDomemaster()` / `renderEquirectangular()` / `renderCubemap()` / `renderStandard()` now switch to the corresponding `ViewType` before rendering.
  - Shader paths extracted to `private static final` constants.
  - **Lazy allocation of the high-resolution output pipeline**: `cubemapRenderer`, `equirectangularRenderer`, `fisheyeDomemaster` and `cubemapViewRenderer` are only created when an external output (NDI/Syphon/Spout) is active.
- **ControlManager**: fields made `private`; new `syncPanelVisibility()` keeps ControlP5 widgets in sync with the `h` key toggle; fish size is applied via `parent.setFishSize()` (now also covers the preview pipeline and avoids NPE with lazy init).
- **FisheyeDomemaster**: null-shader guards in `setFOV()` / `applyShader()`; new `getSizePercentage()` accessor.
- **OutputManager**: `setupSyphonOrSpout()` also catches `LinkageError` so missing native libs can't crash initialization.
- **LogManager**: duplicate-message filter replaced with a time-based throttle (same message at most once per 5 s), so recurring per-frame errors stay visible.
- **README**: OpenGL 1282 known issue updated to reflect the fix shipped in 1.4.0.

### New tests (no GPU context)

- `OutputManagerTest` — toggle flags, unsupported platforms, output view mapping
- `OrbitCameraTest` — `zoom()` clamping, collapse guard, `reset()`, `snapTo()`
- `ZividomeliveLifecycleTest` — `InitState` transitions, target frame rate, `isEnableOutput()` delegation
- `FisheyeDomemasterTest` — `setSizePercentage()` clamping, null-shader safety
- `LogManagerTest` — `setMode()`/`getMode()`, duplicate throttle
- `build.gradle.kts`: local jars (ControlP5/Syphon/Spout) added as `testRuntimeOnly`

### Validation

- `./gradlew build` ✅
- `./gradlew test` ✅ — 88 tests, 0 failures (1 platform-assumption skip)

Invariants preserved: `ViewType`/`InitState` order unchanged, no `beginDraw()` in `sceneRender()`, `LogManager.getLogger()` / `ThreadManager.getExecutor()` conventions kept.