### PR TITLE
docs: reclassify OpenGL error 1282 as endemic known issue

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -253,12 +253,13 @@ Sempre invoca `setupScene()`, podendo reinicializar uma cena em uso.
 if (currentSceneIndex == index) return; // já ativa, não reinicializar
 ```
 
-### 3.12 README ainda lista OpenGL 1282 como known issue não resolvido
+### 3.12 OpenGL Error 1282 — problema endêmico, sem solução completa
 
-**Arquivo**: `README.md` (seção Known Issues)
+**Arquivo**: `README.md` e `docs/en/known-issues.md`
 
-O CHANGELOG 1.4.0 documenta a correção do 1282. O aviso no README deve ser atualizado
-para refletir que o bug foi resolvido (ou removido se a correção for completa em v1.5).
+O erro 1282 (`GL_INVALID_OPERATION`) é **endêmico** a certas combinações de hardware/driver e **não foi resolvido**. O CHANGELOG 1.4.0 documenta apenas a remoção de um caminho de captura NDI que amplificava o problema (nested `beginDraw`/`endDraw`), mas o erro persiste em outras situações (Apple Silicon, drivers específicos, multi-pass).
+
+**Não** tratar nem documentar o 1282 como resolvido. O README e `known-issues.md` devem mantê-lo listado como problema em investigação com workarounds parciais.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 - Dynamic near/far clipping in standard view to avoid object disappearance at large camera distances.
-- OpenGL error `1282` caused by nested `beginDraw()/endDraw()` in scene rendering flow.
+- Reduced frequency of OpenGL error `1282` by removing invalid nested `beginDraw()/endDraw()` calls in the NDI capture path. Note: the error is endemic to certain hardware/driver combinations and may still occur in some configurations.
 - Lifecycle and initialization reliability improvements (register method flow, initialization state handling).
 - `LogManager` thread-safety race condition fix.
 - `FulldomePBR` camera handling corrected to scene-space navigation (without mutating dome control parameters).

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@
 >>Due to the absence of native support for **NDI**, **Syphon**, and **Spout** in this Processing setup, Linux users have reduced external-output options compared with macOS and Windows.
 >
 
->[!NOTE]
->**OpenGL Error 1282 (resolved)**:
-> Earlier versions could emit the following OpenGL error in the Processing console:
+>[!WARNING]
+>**OpenGL Error 1282 (known endemic issue)**:
+> Some configurations may emit the following OpenGL error in the Processing console:
 >   ```
 >   OpenGL error 1282 at bot endDraw(): invalid operation
 >   ```
->This was caused by invalid OpenGL state during output frame capture and has been fixed as of version 1.4.0 by removing the invalid nested draw-context path from NDI capture. If you still see this warning, make sure you are running the latest version of **ziviDomeLive**.
+>This is a `GL_INVALID_OPERATION` emitted by the JOGL/Processing OpenGL driver, typically related to invalid framebuffer state during rendering or output capture. The error is endemic to certain hardware/driver combinations and has not been fully eliminated. It is usually non-fatal and does not interrupt rendering, but may indicate instability in specific setups. We continue to investigate the root cause.
 >
 
 ## Installation

--- a/docs/en/known-issues.md
+++ b/docs/en/known-issues.md
@@ -10,10 +10,15 @@ Linux builds have reduced support for external video outputs compared with macOS
 
 ## OpenGL error 1282
 
-Older builds could emit:
+Some configurations emit:
 
 ```text
 OpenGL error 1282 at bot endDraw(): invalid operation
 ```
 
-This was caused by invalid OpenGL state during output frame capture. The fix shipped in `1.4.0`, and current builds avoid reopening the draw context while preparing NDI frames.
+This is a `GL_INVALID_OPERATION` raised by the JOGL/Processing OpenGL driver, typically triggered by invalid framebuffer state during rendering or output capture. The error is endemic to certain hardware and driver combinations and has not been fully eliminated. It is generally non-fatal — rendering continues — but may indicate instability in specific setups (particularly Apple Silicon, certain GPU drivers, or complex multi-pass rendering). We continue to investigate the root cause.
+
+**Workarounds that may reduce frequency:**
+- Run Processing using the Intel (Rosetta 2) build on Apple Silicon.
+- Keep external outputs (NDI, Syphon, Spout) disabled when not in use.
+- Use the latest GPU drivers for your platform.

--- a/docs/pt/known-issues.md
+++ b/docs/pt/known-issues.md
@@ -1,2 +1,24 @@
 # Problemas Conhecidos
-Lista de problemas conhecidos na biblioteca.
+
+## Apple Silicon e Syphon
+
+No macOS com Apple Silicon, a interoperabilidade completa com Syphon pode exigir a versão Intel do Processing rodando via Rosetta 2. A stack ARM nativa do Processing não oferece o mesmo nível de suporte ao Syphon.
+
+## Outputs externos no Linux
+
+Builds Linux têm suporte reduzido para saídas de vídeo externas em comparação com macOS e Windows, pois as dependências do ecossistema Processing usadas por esta biblioteca não fornecem as mesmas integrações nativas para NDI, Syphon e Spout.
+
+## OpenGL error 1282
+
+Algumas configurações emitem:
+
+```text
+OpenGL error 1282 at bot endDraw(): invalid operation
+```
+
+Esse é um `GL_INVALID_OPERATION` emitido pelo driver OpenGL do JOGL/Processing, geralmente acionado por estado inválido do framebuffer durante renderização ou captura de output. O erro é endêmico em certas combinações de hardware e driver e **não foi completamente eliminado**. Em geral é não-fatal — a renderização continua — mas pode indicar instabilidade em configurações específicas (especialmente Apple Silicon, certos drivers de GPU, ou renderização multi-pass complexa). A investigação da causa raiz está em andamento.
+
+**Medidas que podem reduzir a frequência:**
+- Rode o Processing na versão Intel (Rosetta 2) em Apple Silicon.
+- Mantenha os outputs externos (NDI, Syphon, Spout) desabilitados quando não estiverem em uso.
+- Use os drivers de GPU mais recentes para sua plataforma.


### PR DESCRIPTION
Remove claims that OpenGL error 1282 was resolved. The error is endemic to certain hardware/driver combinations and persists. Updates README, CHANGELOG, known-issues (EN+PT) and copilot-instructions to reflect the ongoing status with workarounds.