### PR TITLE
fix: correct NDI race conditions, slot ownership, and Spout first-frame loss

### DIFF
--- a/src/main/java/com/victorvalentim/zividomelive/manager/OutputManager.java
+++ b/src/main/java/com/victorvalentim/zividomelive/manager/OutputManager.java
@@ -1,7 +1,6 @@
 package com.victorvalentim.zividomelive.manager;
 
 import com.victorvalentim.zividomelive.support.LogManager;
-import com.victorvalentim.zividomelive.support.ThreadManager;
 import com.victorvalentim.zividomelive.zividomelive;
 import me.walkerknapp.devolay.*;
 import processing.core.PConstants;
@@ -11,7 +10,7 @@ import spout.Spout;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -19,16 +18,23 @@ import java.util.logging.Logger;
 /**
  * Manages frame output to NDI, Spout (Windows), and Syphon (macOS).
  *
- * <p>Hot-path design:
+ * <h3>Hot-path design</h3>
  * <ul>
  *   <li>Syphon and Spout are sent first — GPU-to-GPU share, no pixel copy, on the draw thread.
- *   <li>NDI pixels are captured via {@code loadPixels()} on the draw thread, then
- *       ARGB→RGBA conversion + {@code sendVideoFrame()} run on a shared worker thread.
- *   <li>Three pre-allocated NDI frame slots rotate round-robin. An {@link AtomicBoolean}
- *       guard ensures at most one NDI task is queued at any time; excess frames are dropped
- *       (counted via {@link #getNdiDroppedFrames()}) to keep latency bounded.
- *   <li>Graphics references are resolved per-frame so they are always valid after
- *       a {@code resetGraphics()} call.
+ *   <li>NDI uses a producer-consumer model with {@value NDI_SLOT_COUNT} typed slots:
+ *       <ol>
+ *         <li>Draw thread: check slot availability <em>before</em> {@code loadPixels()},
+ *             then {@code System.arraycopy()} raw ARGB pixels into the slot.
+ *         <li>Dedicated NDI worker: ARGB→RGBA conversion, frame configuration, and
+ *             {@code sendVideoFrame()} — all off the draw thread.
+ *         <li>Worker returns slot to the free pool when done.
+ *       </ol>
+ *   <li>If no slot is free when the draw thread checks, the frame is dropped
+ *       ({@link #getNdiDroppedFrames()}) without calling {@code loadPixels()}.
+ *   <li>Graphics references are resolved per-frame so they remain valid after
+ *       {@code resetGraphics()}.
+ *   <li>The NDI worker runs in a dedicated single-thread executor that is created on
+ *       NDI activation and shut down on deactivation, preventing stale tasks after restart.
  * </ul>
  */
 public class OutputManager implements PConstants {
@@ -45,6 +51,37 @@ public class OutputManager implements PConstants {
 
 	private static final int NDI_SLOT_COUNT = 3;
 
+	// -------------------------------------------------------------------------
+	// NDI slot — owns pixel data from copy to send; exclusive ownership via queues.
+	// -------------------------------------------------------------------------
+
+	private static final class NdiSlot implements AutoCloseable {
+		int[] argbPixels = new int[0];
+		ByteBuffer rgbaBuffer = ByteBuffer.allocateDirect(0).order(ByteOrder.LITTLE_ENDIAN);
+		final DevolayVideoFrame frame;
+		int width;
+		int height;
+
+		NdiSlot() { frame = new DevolayVideoFrame(); }
+
+		/** Copies src into this slot and records dimensions. Resizes buffers if needed. */
+		void prepare(int[] src, int w, int h) {
+			int count = w * h;
+			if (argbPixels.length < count) {
+				argbPixels = new int[count];
+				rgbaBuffer = ByteBuffer.allocateDirect(count * 4).order(ByteOrder.LITTLE_ENDIAN);
+			}
+			System.arraycopy(src, 0, argbPixels, 0, count);
+			this.width  = w;
+			this.height = h;
+		}
+
+		@Override
+		public void close() {
+			try { frame.close(); } catch (Exception ignored) {}
+		}
+	}
+
 	private final Logger logger = LogManager.getLogger();
 	private final Map<OutputType, zividomelive.ViewType> outputViews;
 	private final zividomelive parent;
@@ -53,27 +90,35 @@ public class OutputManager implements PConstants {
 	private Spout spoutSender;
 	private SyphonServer syphonServer;
 
-	private boolean ndiEnabled    = false;
+	private volatile boolean ndiEnabled = false;
 	private boolean spoutEnabled  = false;
 	private boolean syphonEnabled = false;
 
 	private final boolean isMacOS;
 	private final boolean isWindows;
 
-	// NDI triple-buffering
-	private final DevolayVideoFrame[] ndiFrames  = new DevolayVideoFrame[NDI_SLOT_COUNT];
-	private final ByteBuffer[]        ndiBuffers = new ByteBuffer[NDI_SLOT_COUNT];
-	private int ndiSlot = 0;
-	private final AtomicBoolean ndiTaskPending = new AtomicBoolean(false);
+	// NDI slot queues — capacity enforces backpressure without blocking the draw thread.
+	private final ArrayBlockingQueue<NdiSlot> freeSlots  = new ArrayBlockingQueue<>(NDI_SLOT_COUNT);
+	private final ArrayBlockingQueue<NdiSlot> readySlots = new ArrayBlockingQueue<>(NDI_SLOT_COUNT - 1);
+
+	// Dedicated NDI worker — one instance per activation cycle; prevents stale tasks after restart.
+	private ExecutorService ndiWorkerExecutor;
+
+	// NDI frame rate metadata (set via setNdiFrameRate; default 60/1)
+	private int ndiFrameRateNum = 60;
+	private int ndiFrameRateDen = 1;
 
 	// NDI metrics
 	private final AtomicLong ndiCaptured = new AtomicLong(0);
 	private final AtomicLong ndiSent     = new AtomicLong(0);
 	private final AtomicLong ndiDropped  = new AtomicLong(0);
 
-	// Spout resolution change tracking
+	// Spout state — reset to 0 on init/shutdown to force explicit createSender on next send.
 	private int spoutLastWidth  = 0;
 	private int spoutLastHeight = 0;
+
+	// setView() deprecation: warn once to avoid log spam.
+	private boolean setViewWarningLogged = false;
 
 	/**
 	 * Constructs the OutputManager.
@@ -119,19 +164,23 @@ public class OutputManager implements PConstants {
 	}
 
 	/**
-	 * Legacy single-view setter — kept for API compatibility only.
+	 * Legacy single-view setter — kept for API compatibility only.  Logs a one-time warning.
 	 *
 	 * @param viewType ignored
 	 * @deprecated Use {@link #setViewForOutput(OutputType, zividomelive.ViewType)} per output.
 	 */
 	@Deprecated
 	public void setView(zividomelive.ViewType viewType) {
-		// No-op — each output has its own view via setViewForOutput().
+		if (!setViewWarningLogged) {
+			logger.warning("setView() is deprecated and has no effect. "
+					+ "Use setViewForOutput() per output type.");
+			setViewWarningLogged = true;
+		}
 	}
 
 	/**
 	 * Returns {@code true} if at least one enabled output is configured to receive
-	 * the given view type. Used by {@code updateRenderViews()} to ensure a view is
+	 * the given view type.  Used by {@code updateRenderViews()} to ensure a view is
 	 * rendered even when it is not the active preview mode.
 	 *
 	 * @param viewType the view type to check
@@ -146,7 +195,7 @@ public class OutputManager implements PConstants {
 	}
 
 	// -------------------------------------------------------------------------
-	// Per-frame graphics resolution (avoids stale references after resetGraphics)
+	// Per-frame graphics resolution
 	// -------------------------------------------------------------------------
 
 	private PGraphicsOpenGL resolveGraphics(OutputType type) {
@@ -187,15 +236,76 @@ public class OutputManager implements PConstants {
 		try {
 			ndiSender = new DevolaySender("ziviDomeLive NDI Output");
 			for (int i = 0; i < NDI_SLOT_COUNT; i++) {
-				ndiFrames[i] = new DevolayVideoFrame();
+				freeSlots.offer(new NdiSlot());
 			}
 			ndiEnabled = true;
+			ndiWorkerExecutor = Executors.newSingleThreadExecutor(r -> {
+				Thread t = new Thread(r, "zividomelive-ndi-worker");
+				t.setDaemon(true);
+				return t;
+			});
+			ndiWorkerExecutor.submit(this::runNdiWorker);
 			logger.info("NDI output initialized.");
 		} catch (LinkageError | IllegalStateException e) {
-			ndiSender = null;
-			Arrays.fill(ndiFrames, null);
-			ndiEnabled = false;
+			cleanupFailedNdiInit();
 			logger.log(Level.WARNING, "initNDI failed: NDI unavailable on this platform.", e);
+		}
+	}
+
+	/**
+	 * Long-running NDI worker loop — runs in {@link #ndiWorkerExecutor}.
+	 * Consumes ready slots, performs ARGB→RGBA conversion, and sends via NDI.
+	 */
+	private void runNdiWorker() {
+		while (ndiEnabled && !Thread.currentThread().isInterrupted()) {
+			NdiSlot slot = null;
+			try {
+				slot = readySlots.poll(100, TimeUnit.MILLISECONDS);
+				if (slot == null) continue;
+
+				// ARGB → RGBA conversion (off the draw thread)
+				int count = slot.width * slot.height;
+				slot.rgbaBuffer.clear();
+				for (int i = 0; i < count; i++) {
+					int px = slot.argbPixels[i];
+					slot.rgbaBuffer.put((byte) ((px >> 16) & 0xFF)); // R
+					slot.rgbaBuffer.put((byte) ((px >> 8)  & 0xFF)); // G
+					slot.rgbaBuffer.put((byte)  (px        & 0xFF)); // B
+					slot.rgbaBuffer.put((byte) ((px >> 24) & 0xFF)); // A
+				}
+				slot.rgbaBuffer.flip();
+
+				slot.frame.setResolution(slot.width, slot.height);
+				slot.frame.setData(slot.rgbaBuffer);
+				slot.frame.setFourCCType(DevolayFrameFourCCType.RGBA);
+				slot.frame.setLineStride(slot.width * 4);
+				slot.frame.setFormatType(DevolayFrameFormatType.INTERLEAVED);
+				slot.frame.setFrameRate(ndiFrameRateNum, ndiFrameRateDen);
+
+				// Check sender while holding lock to guard against concurrent shutdown.
+				DevolaySender sender;
+				synchronized (this) {
+					sender = ndiEnabled ? ndiSender : null;
+				}
+				if (sender != null) {
+					sender.sendVideoFrame(slot.frame);
+					ndiSent.incrementAndGet();
+				}
+				freeSlots.offer(slot);
+
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				if (slot != null) freeSlots.offer(slot);
+				break;
+			} catch (Exception e) {
+				logger.log(Level.WARNING, "NDI worker error.", e);
+				if (slot != null) freeSlots.offer(slot);
+			}
+		}
+		// Drain any remaining ready slots back to the free pool.
+		NdiSlot s;
+		while ((s = readySlots.poll()) != null) {
+			freeSlots.offer(s);
 		}
 	}
 
@@ -204,10 +314,12 @@ public class OutputManager implements PConstants {
 			if (spoutSender == null) {
 				spoutSender = new Spout(parent.getPApplet());
 			}
-			spoutEnabled = true;
+			spoutEnabled    = true;
+			spoutLastWidth  = 0; // force explicit createSender on first sendOutput
+			spoutLastHeight = 0;
 			logger.info("Spout initialized for Windows.");
 		} catch (Exception | LinkageError e) {
-			spoutSender = null;
+			spoutSender  = null;
 			spoutEnabled = false;
 			logger.log(Level.WARNING, "initSpout failed: Spout unavailable on this platform.", e);
 		}
@@ -221,7 +333,7 @@ public class OutputManager implements PConstants {
 			syphonEnabled = true;
 			logger.info("SyphonServer initialized for macOS.");
 		} catch (Exception | LinkageError e) {
-			syphonServer = null;
+			syphonServer  = null;
 			syphonEnabled = false;
 			logger.log(Level.WARNING, "initSyphon failed: Syphon unavailable on this platform.", e);
 		}
@@ -242,17 +354,11 @@ public class OutputManager implements PConstants {
 				if (!ndiEnabled) initNDI(); else shutdownNDI();
 				break;
 			case "spout":
-				if (!isWindows) {
-					logger.warning("Spout toggle ignored: unsupported platform.");
-					return;
-				}
+				if (!isWindows) { logger.warning("Spout toggle ignored: unsupported platform."); return; }
 				if (!spoutEnabled) initSpout(); else shutdownSpout();
 				break;
 			case "syphon":
-				if (!isMacOS) {
-					logger.warning("Syphon toggle ignored: unsupported platform.");
-					return;
-				}
+				if (!isMacOS) { logger.warning("Syphon toggle ignored: unsupported platform."); return; }
 				if (!syphonEnabled) initSyphon(); else shutdownSyphon();
 				break;
 			default:
@@ -261,130 +367,106 @@ public class OutputManager implements PConstants {
 	}
 
 	// -------------------------------------------------------------------------
-	// sendOutput — hot path called every draw frame
+	// sendOutput — hot path, called every draw frame
 	// -------------------------------------------------------------------------
 
 	/**
 	 * Sends the current rendered frame to all active outputs.
 	 *
 	 * <p>Must be called from the Processing draw thread after all render views have
-	 * been updated. Syphon and Spout are processed first (GPU texture share, minimal
-	 * overhead). NDI pixels are captured here and forwarded to a worker thread.
+	 * been updated (i.e., after {@code updateRenderViews()} completes).
+	 *
+	 * <p>Syphon and Spout are sent first (GPU texture share, minimal overhead).
+	 * NDI availability is checked before {@code loadPixels()} to avoid unnecessary
+	 * CPU work when the NDI worker is busy.
 	 */
 	public void sendOutput() {
-		// Syphon — macOS GPU-to-GPU, remains on draw thread
+		// Syphon — macOS GPU-to-GPU, stays on draw thread
 		if (syphonEnabled && syphonServer != null && isMacOS) {
 			try {
 				PGraphicsOpenGL pg = resolveGraphics(OutputType.SYPHON);
 				if (pg != null) {
 					syphonServer.sendImage(pg);
 				}
-			} catch (Exception e) {
+			} catch (Exception | LinkageError e) {
 				logger.log(Level.WARNING, "sendOutput: Syphon error.", e);
 			}
 		}
 
-		// Spout — Windows GPU-to-GPU, remains on draw thread
+		// Spout — Windows GPU-to-GPU, stays on draw thread
 		if (spoutEnabled && spoutSender != null && isWindows) {
 			try {
 				PGraphicsOpenGL pg = resolveGraphics(OutputType.SPOUT);
 				if (pg != null) {
-					if (pg.width != spoutLastWidth || pg.height != spoutLastHeight) {
+					if (spoutLastWidth == 0 || spoutLastHeight == 0) {
+						// Explicit sender creation on first frame avoids the lost-first-frame
+						// issue caused by Spout's lazy createSender inside sendTexture().
+						spoutSender.createSender("ziviDomeLive Spout", pg.width, pg.height);
 						spoutLastWidth  = pg.width;
 						spoutLastHeight = pg.height;
-						logger.info("Spout resolution: " + spoutLastWidth + "×" + spoutLastHeight);
+					} else if (pg.width != spoutLastWidth || pg.height != spoutLastHeight) {
+						// Explicit update before sendTexture prevents the lost-frame-on-resize
+						// issue caused by Spout's lazy updateSender inside sendTexture().
+						spoutSender.updateSender(pg.width, pg.height);
+						spoutLastWidth  = pg.width;
+						spoutLastHeight = pg.height;
 					}
 					spoutSender.sendTexture(pg);
 				}
-			} catch (Exception e) {
+			} catch (Exception | LinkageError e) {
 				logger.log(Level.WARNING, "sendOutput: Spout error.", e);
 			}
 		}
 
-		// NDI — pixel capture on draw thread, conversion + send on worker thread
+		// NDI — pixel copy on draw thread, conversion + send in dedicated worker
 		if (ndiEnabled && ndiSender != null) {
 			try {
 				PGraphicsOpenGL pg = resolveGraphics(OutputType.NDI);
-				if (pg != null && pg.width > 0 && pg.height > 0) {
-					pg.loadPixels(); // must stay on draw thread
-					int[] pixels = pg.pixels;
-					if (pixels != null && pixels.length == pg.width * pg.height) {
-						submitNDIFrame(pixels, pg.width, pg.height);
-					}
+				if (pg == null || pg.width <= 0 || pg.height <= 0) return;
+
+				// Availability check BEFORE loadPixels — drops frame without CPU work if busy.
+				NdiSlot slot = freeSlots.poll();
+				if (slot == null) {
+					ndiDropped.incrementAndGet();
+					return;
 				}
-			} catch (Exception e) {
+
+				pg.loadPixels(); // must run on draw thread
+				int[] pixels = pg.pixels;
+				if (pixels == null || pixels.length < pg.width * pg.height) {
+					freeSlots.offer(slot); // return slot on bad state
+					return;
+				}
+
+				// System.arraycopy is significantly faster than element-wise copy.
+				slot.prepare(pixels, pg.width, pg.height);
+				ndiCaptured.incrementAndGet();
+
+				if (!readySlots.offer(slot)) {
+					// readySlots full — worker is overloaded, drop and return slot.
+					freeSlots.offer(slot);
+					ndiDropped.incrementAndGet();
+				}
+			} catch (Exception | LinkageError e) {
 				logger.log(Level.WARNING, "sendOutput: NDI capture error.", e);
 			}
 		}
-	}
-
-	/**
-	 * Copies pixel data into the next NDI slot and submits a worker task to send it.
-	 * Drops the frame (incrementing the dropped counter) if the previous task is still running.
-	 */
-	private void submitNDIFrame(int[] pixels, int width, int height) {
-		int slot = ndiSlot;
-		ndiSlot = (ndiSlot + 1) % NDI_SLOT_COUNT;
-
-		int byteCount = width * height * 4;
-		if (ndiBuffers[slot] == null || ndiBuffers[slot].capacity() != byteCount) {
-			ndiBuffers[slot] = ByteBuffer.allocateDirect(byteCount).order(ByteOrder.LITTLE_ENDIAN);
-		}
-		ByteBuffer buf = ndiBuffers[slot];
-		buf.clear();
-		for (int px : pixels) {
-			buf.put((byte) ((px >> 16) & 0xFF)); // R
-			buf.put((byte) ((px >> 8)  & 0xFF)); // G
-			buf.put((byte)  (px        & 0xFF)); // B
-			buf.put((byte) ((px >> 24) & 0xFF)); // A
-		}
-		buf.flip();
-
-		DevolayVideoFrame frame = ndiFrames[slot];
-		if (frame == null) return;
-		frame.setResolution(width, height);
-		frame.setData(buf);
-		frame.setFourCCType(DevolayFrameFourCCType.RGBA);
-		frame.setLineStride(width * 4);
-		frame.setFormatType(DevolayFrameFormatType.INTERLEAVED);
-		frame.setFrameRate(60, 1);
-
-		ndiCaptured.incrementAndGet();
-
-		if (!ndiTaskPending.compareAndSet(false, true)) {
-			// Worker busy — drop frame to keep queue bounded
-			ndiDropped.incrementAndGet();
-			return;
-		}
-
-		final int capturedSlot = slot;
-		ThreadManager.submitRunnable(() -> {
-			try {
-				synchronized (OutputManager.this) {
-					if (ndiSender != null && ndiEnabled) {
-						ndiSender.sendVideoFrame(ndiFrames[capturedSlot]);
-						ndiSent.incrementAndGet();
-					}
-				}
-			} catch (Exception e) {
-				logger.log(Level.WARNING, "NDI sendVideoFrame error.", e);
-			} finally {
-				ndiTaskPending.set(false);
-			}
-		});
 	}
 
 	// -------------------------------------------------------------------------
 	// NDI metrics
 	// -------------------------------------------------------------------------
 
-	/** Returns the total number of NDI frames for which loadPixels() was called. */
+	/** Returns the total number of NDI frames for which {@code loadPixels()} was called. */
 	public long getNdiCapturedFrames() { return ndiCaptured.get(); }
 
 	/** Returns the total number of NDI frames successfully transmitted. */
 	public long getNdiSentFrames()     { return ndiSent.get(); }
 
-	/** Returns the number of NDI frames dropped due to a busy worker thread. */
+	/**
+	 * Returns the number of NDI frames dropped because no slot was available
+	 * (worker busy) or the ready queue was full.
+	 */
 	public long getNdiDroppedFrames()  { return ndiDropped.get(); }
 
 	// -------------------------------------------------------------------------
@@ -402,15 +484,34 @@ public class OutputManager implements PConstants {
 		logger.info("All output services have been shut down.");
 	}
 
-	private synchronized void shutdownNDI() {
-		if (ndiSender != null) {
-			ndiSender.close();
-			ndiSender = null;
+	private void shutdownNDI() {
+		ndiEnabled = false; // volatile write — worker sees this immediately
+
+		// Capture and clear the executor reference before waiting for termination
+		// to avoid holding a lock across awaitTermination (which could deadlock if
+		// the worker tries to acquire the same lock during shutdown).
+		ExecutorService executor;
+		synchronized (this) {
+			executor = ndiWorkerExecutor;
+			ndiWorkerExecutor = null;
 		}
-		Arrays.fill(ndiFrames,  null);
-		Arrays.fill(ndiBuffers, null);
-		ndiEnabled = false;
-		ndiTaskPending.set(false);
+		if (executor != null) {
+			executor.shutdownNow();
+			try {
+				executor.awaitTermination(500, TimeUnit.MILLISECONDS);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+		// Close sender after worker has exited to avoid concurrent use.
+		synchronized (this) {
+			if (ndiSender != null) {
+				ndiSender.close();
+				ndiSender = null;
+			}
+		}
+		drainAndCloseSlots(freeSlots);
+		drainAndCloseSlots(readySlots);
 		logger.info("NDI output shut down.");
 	}
 
@@ -434,20 +535,35 @@ public class OutputManager implements PConstants {
 		logger.info("Syphon output shut down.");
 	}
 
+	private void cleanupFailedNdiInit() {
+		if (ndiSender != null) { ndiSender.close(); ndiSender = null; }
+		ndiEnabled = false;
+		drainAndCloseSlots(freeSlots);
+		drainAndCloseSlots(readySlots);
+	}
+
+	/** Drains {@code queue}, calling {@link NdiSlot#close()} on each slot. */
+	private void drainAndCloseSlots(Queue<NdiSlot> queue) {
+		NdiSlot slot;
+		while ((slot = queue.poll()) != null) {
+			slot.close();
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// Status
 	// -------------------------------------------------------------------------
 
-	/** Returns true if NDI output is enabled. */
+	/** Returns true if NDI output is currently enabled. */
 	public boolean isNdiEnabled()    { return ndiEnabled;    }
 
-	/** Returns true if Spout output is enabled. */
+	/** Returns true if Spout output is currently enabled. */
 	public boolean isSpoutEnabled()  { return spoutEnabled;  }
 
-	/** Returns true if Syphon output is enabled. */
+	/** Returns true if Syphon output is currently enabled. */
 	public boolean isSyphonEnabled() { return syphonEnabled; }
 
-	/** Returns true if at least one output is currently active. */
+	/** Returns true if at least one output method is currently active. */
 	public boolean isActive() {
 		return (ndiEnabled    && ndiSender    != null)
 			|| (spoutEnabled  && spoutSender  != null)
@@ -467,12 +583,27 @@ public class OutputManager implements PConstants {
 	/** Sets the view type for Syphon output. */
 	public void setSyphonView(zividomelive.ViewType view) { setViewForOutput(OutputType.SYPHON, view); }
 
+	/**
+	 * Sets the NDI frame rate metadata. Common values:
+	 * <ul>
+	 *   <li>{@code 60, 1} → 60 fps (default)
+	 *   <li>{@code 30, 1} → 30 fps
+	 *   <li>{@code 60000, 1001} → 59.94 fps
+	 * </ul>
+	 *
+	 * @param numerator   frame rate numerator (must be &gt; 0)
+	 * @param denominator frame rate denominator (must be &gt; 0)
+	 */
+	public void setNdiFrameRate(int numerator, int denominator) {
+		if (numerator > 0 && denominator > 0) {
+			ndiFrameRateNum = numerator;
+			ndiFrameRateDen = denominator;
+		}
+	}
+
 	/** Stops all output methods. Alias for {@link #shutdownOutputs()}. */
 	public void stopOutput() { shutdownOutputs(); }
 
-	/**
-	 * No-op — retained for call-site compatibility with the previous cached-graphics
-	 * implementation. Graphics references are now resolved per-frame.
-	 */
+	/** No-op — retained for call-site compatibility. Graphics are now resolved per-frame. */
 	public void refreshCachedGraphics() { /* per-frame resolution — no cache to refresh */ }
 }


### PR DESCRIPTION
## Problemas corrigidos (revisão de código)

### NDI — condição de corrida crítica no triple-buffering
O código anterior avançava o índice circular **antes** do CAS, permitindo que a thread gráfica sobrescrevesse o mesmo buffer que o worker estava transmitindo.

**Fix:** modelo produtor-consumidor com dois `ArrayBlockingQueue`:
- `freeSlots` (cap=3): slots disponíveis para o draw thread
- `readySlots` (cap=2): slots prontos para o worker
- Ownership exclusivo garantido pelas operações de fila (happens-before)
- Disponibilidade verificada **antes** de `loadPixels()` — frames descartados sem custo de CPU

### NDI — conversão ARGB→RGBA ainda bloqueava o draw thread
`System.arraycopy()` no draw thread copia ARGB bruto; conversão + `sendVideoFrame()` movidos inteiramente para o worker dedicado.

### NDI — tarefas antigas após reinicialização
Executor dedicado (`newSingleThreadExecutor`) por ciclo de ativação, encerrado em `shutdownNDI()`. `awaitTermination` chamado **sem** segurar o lock (evita deadlock).

### NDI — vazamento de recursos nativos
`DevolayVideoFrame.close()` chamado em cada slot em `drainAndCloseSlots()`.

### Spout — primeiro frame perdido
`createSender()` chamado explicitamente antes de `sendTexture()` no primeiro frame (`spoutLastWidth==0`), contornando o init lazy do Spout.

### Spout — frame perdido em mudança de resolução
`updateSender()` chamado explicitamente quando resolução muda, antes de `sendTexture()`.

### Geral
- `LinkageError` capturado em todos os paths de `sendOutput()`
- `setNdiFrameRate(num, den)` para metadado correto (ex: 60000/1001 para 59.94fps)
- `setView()` loga warning uma vez ao invés de ser silencioso

## Testes
`./gradlew test build` ✅