### PR TITLE
fix: correct Javadoc heading in OutputManager

### DIFF
--- a/src/main/java/com/victorvalentim/zividomelive/manager/OutputManager.java
+++ b/src/main/java/com/victorvalentim/zividomelive/manager/OutputManager.java
@@ -18,7 +18,7 @@ import java.util.logging.Logger;
 /**
  * Manages frame output to NDI, Spout (Windows), and Syphon (macOS).
  *
- * <h3>Hot-path design</h3>
+ * <h2>Hot-path design</h2>
  * <ul>
  *   <li>Syphon and Spout are sent first — GPU-to-GPU share, no pixel copy, on the draw thread.
  *   <li>NDI uses a producer-consumer model with {@value NDI_SLOT_COUNT} typed slots:


### PR DESCRIPTION
Fixes `error: heading used out of sequence: <H3>` that broke `./gradlew javadoc`.\n\nChanged `<h3>Hot-path design</h3>` → `<h2>` (class-level implicit heading is H1).