### PR TITLE
Update Devolay to 2.2.0-vic.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ version = "1.4.0"
 
 // Centralized dependency versions for easier Maven sync/updates.
 val processingCoreVersion = "4.5.6"
-val devolayVersion = "2.1.1"
+val devolayVersion = "2.2.0-vic.1"
 
 // The location of your sketchbook folder. The sketchbook folder holds your installed
 // libraries, tools, and modes. It is needed if you:
@@ -88,7 +88,7 @@ dependencies {
     compileOnly(group = "org.processing", name = "core", version = processingCoreVersion)
 
     // insert your external dependencies
-    implementation(group = "me.walkerknapp", name = "devolay", version = devolayVersion)
+    implementation(group = "io.github.vicvalentim", name = "devolay", version = devolayVersion)
     //implementation(group = "org.apache.commons", name = "commons-math3", version = "3.6.1")
     // The provided example uses commons-math3. Replace or add as needed.
 


### PR DESCRIPTION
Updates ziviDomeLive from the upstream Devolay 2.1.1 artifact to the community-maintained Maven Central release:

- io.github.vicvalentim:devolay:2.2.0-vic.1
- preserves the existing me.walkerknapp.devolay Java package/API
- adds native macOS Apple Silicon support
- validated against NDI 6.3.2
- resolved directly from Maven Central
- clean test/build passed
- Processing release packaging passed
- public package contains Devolay JNI natives but no proprietary NDI runtime
- runtime test passed on Apple Silicon
- ziviDomeLive NDI sender initialized successfully
- FISHEYE_DOMEMASTER output confirmed through NDI

Validation:
- ./gradlew --refresh-dependencies dependencyInsight --dependency devolay --configuration runtimeClasspath
- ./gradlew clean test build
- ./gradlew buildReleaseArtifacts
- runtime NDI test in Processing / NDI Monitor